### PR TITLE
[TASK] Compatibility with TYPO3 10 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "type": "typo3-cms-extension",
   "description": "Adds support for typolink addQueryString to allow to include only specific url vars.",
   "require": {
-    "typo3/cms-core": "~7.6 || ~8.7 || ~9.5"
+    "typo3/cms-core": "~7.6 || ~8.7 || ~9.5 || ~10.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '7.6.0-9.5.999',
+                    'typo3' => '7.6.0-10.4.999',
                 ],
             'conflicts' =>
                 [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,8 +1,11 @@
 <?php
 
 call_user_func(function () {
-    $configuration = is_string($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['urlguard']) ?
-        @unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['urlguard']) : [];
+    if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
+        $configuration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('urlguard');
+    } else {
+        $configuration = is_string($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['urlguard']) ? @unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['urlguard']) : [];
+    }
     if (!empty($configuration['enableXclassForContentObjectRenderer'])) {
         if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) <= 8007999) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class] = [


### PR DESCRIPTION
Hi,

first of all thanks for your great extension. It is really helpful!

I want to use it in a TYPO3 v10 project and had a look what needs to be changed. As far as I can see, only the use of `$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['urlguard']` needs to be removed. To keep backwards compatibility, as you always did, I introduced the new way with an `if`. Would be great, if you could have a look and maybe merge it into your extension.